### PR TITLE
Assembly support for multiple mixed type read assembly

### DIFF
--- a/methods/assemble_contigset_from_reads/display.yaml
+++ b/methods/assemble_contigset_from_reads/display.yaml
@@ -42,6 +42,14 @@ parameters :
         long-hint  : |
             the read files can be directly specified here
 
+    reference :
+        ui-name : |
+            Reference Assembly
+        short-hint : |
+            the reference contig set can used to evaluate the quality of the de novo assembly
+        long-hint  : |
+            the reference contig set can used to evaluate the quality of the de novo assembly
+
     description :
         ui-name : |
             Description

--- a/methods/assemble_contigset_from_reads/spec.json
+++ b/methods/assemble_contigset_from_reads/spec.json
@@ -1,5 +1,5 @@
 {
-  "ver" : "1.0.0",
+  "ver" : "1.1.0",
   "authors" : [ "fangfang", "cbun" ],
   "contact" : "help@kbase.us",
   "visble" : true,
@@ -21,17 +21,27 @@
   }, {
     "id" : "read_library",
     "optional" : true,
-    "advanced" : true,
+    "advanced" : false,
     "allow_multiple" : true,
     "default_values" : [ "" ],
     "field_type" : "text",
     "text_options" : {
-      "valid_ws_types" : [ "KBaseAssembly.SingleEndLibrary", "KBaseAssembly.PairedEndLibrary" ]
+      "valid_ws_types" : [ "KBaseAssembly.SingleEndLibrary", "KBaseAssembly.PairedEndLibrary", "KBaseFile.SingleEndLibrary", "KBaseFile.PairedEndLibrary" ]
+    }
+  }, {
+    "id" : "reference",
+    "optional" : true,
+    "advanced" : true,
+    "allow_multiple" : false,
+    "default_values" : [ "" ],
+    "field_type" : "text",
+    "text_options" : {
+      "valid_ws_types" : [ "KBaseAssembly.ReferenceAssembly" ]
     }
   }, {
     "id" : "description",
-    "optional" : false,
-    "advanced" : false,
+    "optional" : true,
+    "advanced" : true,
     "allow_multiple" : false,
     "default_values" : [ "" ],
     "field_type" : "textarea",
@@ -152,12 +162,28 @@
           "target_property": "assembly_input"
         },
         {
+          "input_parameter": "read_library",
+          "target_property": "read_library"
+        },
+        {
+          "input_parameter": "reference",
+          "target_property": "reference"
+        },
+        {
           "input_parameter": "description",
           "target_property": "description"
         },
         {
           "input_parameter": "recipe",
           "target_property": "recipe"
+        },
+        {
+          "input_parameter": "assembler",
+          "target_property": "assembler"
+        },
+        {
+          "input_parameter": "pipeline",
+          "target_property": "pipeline"
         },
         {
           "input_parameter": "output_contigset",
@@ -168,6 +194,14 @@
         }
       ],
       "output_mapping" : [
+        {
+          "input_parameter": "output_contigset",
+          "target_property": "id"
+        },
+        {
+          "narrative_system_variable": "workspace",
+          "target_property": "ws"
+        }
       ]
     }
   }


### PR DESCRIPTION
This commit depends on the NJS handling of unrolled multiple mixed type parameters for the script mode. 