### PR TITLE
updates to use revised output widgets

### DIFF
--- a/methods/simulate_growth_on_a_phenotype_set/spec.json
+++ b/methods/simulate_growth_on_a_phenotype_set/spec.json
@@ -7,7 +7,7 @@
   "categories" : ["active"],
   "widgets" : {
     "input" : null,
-    "output" : "kbaseSimulationSet"
+    "output" : "kbaseTabTable"
   },
   "parameters" : [ {
     "id" : "input_model",
@@ -74,8 +74,12 @@
       ],
       "output_mapping" : [
         {
+          "constant_value": "KBasePhenotypes.PhenotypeSimulationSet",
+          "target_property": "type"
+        },
+        {
           "input_parameter": "output_phenosim",
-          "target_property": "id"
+          "target_property": "obj"
         },
         {
           "narrative_system_variable": "workspace",

--- a/methods/view_media/spec.json
+++ b/methods/view_media/spec.json
@@ -7,7 +7,7 @@
   "categories" : ["viewers"],
   "widgets" : {
     "input" : null,
-    "output" : "kbaseMediaViewer"
+    "output" : "kbaseTabTable"
   },
   "parameters" : [ {
     "id" : "param0",
@@ -24,8 +24,12 @@
     "none" : {
       "output_mapping" : [
         {
+          "constant_value": "KBaseBiochem.Media",
+          "target_property": "type"
+        },
+        {
           "input_parameter": "param0",
-          "target_property": "id"
+          "target_property": "obj"
         },
         {
           "narrative_system_variable": "workspace",

--- a/methods/view_phenotype_set/spec.json
+++ b/methods/view_phenotype_set/spec.json
@@ -7,7 +7,7 @@
   "categories" : ["viewers"],
   "widgets" : {
     "input" : null,
-    "output" : "kbasePhenotypeSet"
+    "output" : "kbaseTabTable"
   },
   "parameters" : [ {
     "id" : "param0",
@@ -24,8 +24,12 @@
     "none" : {
       "output_mapping" : [
         {
+          "constant_value": "KBasePhenotypes.PhenotypeSet",
+          "target_property": "type"
+        },
+        {
           "input_parameter": "param0",
-          "target_property": "name"
+          "target_property": "obj"
         },
         {
           "narrative_system_variable": "workspace",

--- a/methods/view_phenotype_simulation_results/spec.json
+++ b/methods/view_phenotype_simulation_results/spec.json
@@ -7,7 +7,7 @@
   "categories" : ["viewers"],
   "widgets" : {
     "input" : null,
-    "output" : "kbaseSimulationSet"
+    "output" : "kbaseTabTable"
   },
   "parameters" : [ {
     "id" : "param0",
@@ -24,8 +24,12 @@
     "none" : {
       "output_mapping" : [
         {
+          "constant_value": "KBasePhenotypes.PhenotypeSimulationSet",
+          "target_property": "type"
+        },
+        {
           "input_parameter": "param0",
-          "target_property": "name"
+          "target_property": "obj"
         },
         {
           "narrative_system_variable": "workspace",


### PR DESCRIPTION
Adds revised widgets for media, phenotypeSet, and phenotypeSimulationSet.  This should be merged with the deploy of my PR for the narrative: https://github.com/kbase/narrative/pull/204