### PR TITLE
output genome name set to be required in annotate_contigset method

### DIFF
--- a/methods/annotate_contigset/spec.json
+++ b/methods/annotate_contigset/spec.json
@@ -73,7 +73,7 @@
     }
   }, {
     "id" : "output_genome",
-    "optional" : true,
+    "optional" : false,
     "advanced" : false,
     "allow_multiple" : false,
     "default_values" : [ "" ],


### PR DESCRIPTION
A fix for auto generated output names that are being regenerated at the wrong time.

https://atlassian.kbase.us/browse/KBASE-1304