### PR TITLE
Urgent: So the URL validation performed in narrative is blocking my efforts to use the impl URL to induce the awe worker nodes to operate locally rather than using RPC calls. So I'm taking another tactic: using a constant parameter called "localmode" which I would alter the NJS job script to recognize. Can we check this in right away?

### DIFF
--- a/methods/run_flux_balance_analysis/spec.json
+++ b/methods/run_flux_balance_analysis/spec.json
@@ -166,10 +166,14 @@
   } ],
   "behavior" : {
     "service-mapping" : {
-      "url" : "impl",
+      "url" : "",
       "name" : "KBaseFBAModeling",
       "method" : "runfba",
       "input_mapping" : [
+        {
+          "constant_value": "1",
+          "target_property": "localmode"
+        },
         {
           "input_parameter": "input_model",
           "target_property": "model"


### PR DESCRIPTION
Urgent: So the URL validation performed in narrative is blocking my efforts to use the impl URL to induce the awe worker nodes to operate locally rather than using RPC calls. So I'm taking another tactic: using a constant parameter called "localmode" which I would alter the NJS job script to recognize. Can we check this in right away?