### PR TITLE
Setting the five longest running modeling methods to operate locally

### DIFF
--- a/methods/compute_pangenome/spec.json
+++ b/methods/compute_pangenome/spec.json
@@ -48,6 +48,10 @@
       "method" : "build_pangenome",
       "input_mapping" : [
         {
+          "constant_value": "1",
+          "target_property": "localmode"
+        },
+        {
           "input_parameter": "input_genomeset",
           "target_property": "pangenome_set"
         },

--- a/methods/gapfill_a_metabolic_model/spec.json
+++ b/methods/gapfill_a_metabolic_model/spec.json
@@ -69,6 +69,10 @@
       "method" : "gapfill_model",
       "input_mapping" : [
         {
+          "constant_value": "1",
+          "target_property": "localmode"
+        },
+        {
           "input_parameter": "input_model",
           "target_property": "model"
         },

--- a/methods/merge_to_community_model/spec.json
+++ b/methods/merge_to_community_model/spec.json
@@ -48,6 +48,10 @@
       "method" : "models_to_community_model",
       "input_mapping" : [
         {
+          "constant_value": "1",
+          "target_property": "localmode"
+        },
+        {
           "input_parameter": "input_models",
           "target_property": "community_submodel_ids"
         },

--- a/methods/metagenome_annotation_to_models/spec.json
+++ b/methods/metagenome_annotation_to_models/spec.json
@@ -68,6 +68,10 @@
       "method" : "metagenome_to_fbamodels",
       "input_mapping" : [
         {
+          "constant_value": "1",
+          "target_property": "localmode"
+        },
+        {
           "input_parameter": "input_metagenome",
           "target_property": "metaanno_uid"
         },

--- a/methods/simulate_growth_on_a_phenotype_set/spec.json
+++ b/methods/simulate_growth_on_a_phenotype_set/spec.json
@@ -48,6 +48,10 @@
       "method" : "simulate_phenotypes",
       "input_mapping" : [
         {
+          "constant_value": "1",
+          "target_property": "localmode"
+        },
+        {
           "input_parameter": "input_model",
           "target_property": "model"
         },


### PR DESCRIPTION
As previously proposed, now that FBA successfully passed testing running in local mode, I want to transition the 5 longest running functions, dramatically reducing risk of time outs in calls and dramatically increasing our scalability.