### PR TITLE
Trivial change to enable travis-ci testing on all branches

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,9 +11,3 @@ install:
 
 script: make test
 
-branches:
-  only:
-  - master
-  - staging
-  - develop
-  - dev

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-**master:** [![Build Status](https://travis-ci.org/kbase/narrative_method_specs.svg?branch=master)](https://travis-ci.org/kbase/narrative_method_specs) | **staging:** [![Build Status](https://travis-ci.org/kbase/narrative_method_specs.svg?branch=staging)](https://travis-ci.org/kbase/narrative_method_specs) | **develop:** [![Build Status](https://travis-ci.org/kbase/narrative_method_specs.svg?branch=develop)](https://travis-ci.org/kbase/narrative_method_specs)
+**master:** [![Build Status](https://travis-ci.org/kbase/narrative_method_specs.svg?branch=master)](https://travis-ci.org/kbase/narrative_method_specs) | **staging:** [![Build Status](https://travis-ci.org/kbase/narrative_method_specs.svg?branch=staging)](https://travis-ci.org/kbase/narrative_method_specs) | **develop:** [![Build Status](https://travis-ci.org/kbase/narrative_method_specs.svg?branch=develop)](https://travis-ci.org/kbase/narrative_method_specs) | **CI:** [![Build Status](https://travis-ci.org/kbase/narrative_method_specs.svg?branch=ci)](https://travis-ci.org/kbase/narrative_method_specs)
 
 Narrative Method & App Specifications
 -----------------------------------------------


### PR DESCRIPTION
Also added a badge to indicate test status on the 'ci' branch in the README file.