### PR TITLE
Added new basic methods to support Expression Data Matrix

### DIFF
--- a/methods/expression_toolkit_reconnect_to_genome/display.yaml
+++ b/methods/expression_toolkit_reconnect_to_genome/display.yaml
@@ -1,0 +1,57 @@
+#
+# Define basic display information
+#
+name     : Associate Expression Data Matrix to Genome Features
+
+tooltip  : |
+    Associate expression data matrix rows to genome features by ID or alias
+
+screenshots :
+    []
+
+replacement-text : Associated Expression data {{{input_data}}} to Genome {{{genome_id}}}
+#
+# Define the set of other narrative methods that should be suggested to the user.
+#
+suggestions :
+    apps:
+        related :
+            []
+        next :
+            []
+    methods:
+        related :
+            []
+        next :
+            []
+
+
+#
+# Configure the display and description of the parameters
+#
+parameters :
+    input_data:
+        ui-name : |
+            Expression Matrix
+        short-hint : |
+            Expression data to associate with genome features
+
+    genome_id:
+        ui-name : |
+            Genome
+        short-hint : |
+            Genome containing features referenced by the selected Expression Matrix
+
+    out_matrix_id :
+        ui-name : |
+            Output Expression Matrix Name
+        short-hint : |
+            Provide a name for the new expresion data matrix associated with the genome
+
+
+description : |
+    This method accepts an Expression data matrix and a Genome and attempts to associate
+    the rows in the data to features in the Genome.  The matching is performed by simply comparing
+    the row IDs to genome feature IDs or aliases.  Methods that operate on expression data
+    often rely on this mapping between rows and features to properly function.
+

--- a/methods/expression_toolkit_reconnect_to_genome/spec.json
+++ b/methods/expression_toolkit_reconnect_to_genome/spec.json
@@ -1,0 +1,87 @@
+{
+  "name" : "Expression Toolkit reconnect matrix to genome",
+  "ver" : "1.0.0",
+  "authors" : [ ],
+  "contact" : "help@kbase.us",
+  "visble" : true,
+  "categories" : ["active"],
+  "widgets" : {
+    "input" : null,
+    "output" : "kbaseExpressionMatrix"
+  },
+  "parameters" : [ {
+    "id" : "input_data",
+    "optional" : false,
+    "advanced" : false,
+    "allow_multiple" : false,
+    "default_values" : [ "" ],
+    "field_type" : "text",
+    "text_options" : {
+      "valid_ws_types" : [ "KBaseFeatureValues.ExpressionMatrix" ]
+    }
+  }, {
+    "id" : "genome_id",
+    "optional" : false,
+    "advanced" : false,
+    "allow_multiple" : false,
+    "default_values" : [ "" ],
+    "field_type" : "text",
+    "text_options" : {
+      "valid_ws_types" : [ "KBaseGenomes.Genome" ]
+    }
+  }, {
+    "id" : "out_matrix_id",
+    "optional" : true,
+    "advanced" : false,
+    "allow_multiple" : false,
+    "default_values" : [ "" ],
+    "field_type" : "text",
+    "text_options" : {
+      "valid_ws_types" : [ "KBaseFeatureValues.ExpressionMatrix" ],
+      "is_output_name":true
+    }
+  } ],
+  "behavior" : {
+    "service-mapping" : {
+      "url" : "https://kbase.us/services/feature_values/jsonrpc",
+      "name" : "KBaseFeatureValues",
+      "method" : "reconnect_matrix_to_genome",
+      "input_mapping" : [
+        {
+          "input_parameter": "input_data",
+          "target_property": "input_data",
+          "target_type_transform": "ref"
+        },
+        {
+          "input_parameter": "genome_id",
+          "target_property": "genome_ref",
+          "target_type_transform": "ref"
+        },
+        {
+          "narrative_system_variable": "workspace",
+          "target_property": "out_workspace"
+        },
+        {
+          "input_parameter": "out_matrix_id",
+          "target_property": "out_matrix_id"
+        }
+      ],
+      "output_mapping" : [
+        {
+          "input_parameter": "out_matrix_id",
+          "target_property": "expressionMatrixID"
+        },
+        {
+          "narrative_system_variable": "workspace",
+          "target_property": "workspaceID"
+        },
+        {
+          "service_method_output_path": [],
+          "target_property": "job_id"
+        }
+      ]
+    }
+  },
+  "job_id_output_field": "job_id"
+}
+

--- a/methods/import_expression_tsv_file/display.yaml
+++ b/methods/import_expression_tsv_file/display.yaml
@@ -1,0 +1,45 @@
+name     : EXPRESSION MATRIX FROM TSV FILE
+subtitle : none
+tooltip  : Upload an expression data matrix from a TSV file.
+
+screenshots :
+    []
+
+method-suggestions :
+    related :
+        []
+    next :
+        []
+
+parameters :
+    expressionFile :
+        ui-name : Expression Data TSV File
+        short-hint : File with expression data in TSV format with Features in rows and Conditions in columns
+        long-hint  : The filename should end with ".tsv"
+
+    outputObject :
+        ui-name : New Expression Data Matrix Name
+        short-hint : Provide the name for the Expression Matrix object that will be created by this upload
+
+    genomeObject :
+        ui-name : Genome
+        short-hint : Select the Genome object that contains features referenced by the Expression Matrix
+        long-hint  : Feature IDs as listed in the first column will be matched against feature ids or aliases of the Genome
+
+    fillMissingValues :
+        ui-name : Impute missing values?
+        short-hint : Check here to fill any missing values in the data
+
+    dataType :
+        ui-name : Value Type
+        short-hint : |
+            Indicate if the numbers are absolute expression levels, ratios, or log-ratios
+
+    dataScale :
+        ui-name : Value Scaling Factor
+        short-hint : If the data was rescaled by a constant factor, indicate that here
+
+description :  
+    <p> This upload method enables users to upload gene expression matrix in TSV format into the narrative.</p>
+    <p> Begin by selecting the ExpressionMatrix type in the dropdown (in Import tab ) and click Next. Select the .tsv file for upload and click Import </p>
+    <p> The .tsv file is a tab delimited text file, with genes across the rows and sample/observations across the columns. Each row (gene) should have an identifier (in green) that always goes in the first column.  Each column (sample) should have a label (in blue) that is always in the first row.  The remaining cells in the table contain expression values for the appropriate gene and sample. </p>

--- a/methods/import_expression_tsv_file/spec.json
+++ b/methods/import_expression_tsv_file/spec.json
@@ -1,0 +1,101 @@
+{
+  "ver" : "1.0.0",
+  "authors" : [ ],
+  "contact" : "help@kbase.us",
+  "visble" : true,
+  "categories" : [ "importers" ],
+  "widgets" : {
+    "input" : "kbaseNarrativeMethodInput"
+  },
+  "parameters" : [ {
+    "id" : "expressionFile",
+    "optional" : false,
+    "advanced" : false,
+    "allow_multiple" : false,
+    "default_values" : [ "" ],
+    "field_type" : "file",
+    "text_options" : {
+      "valid_ws_types" : [ ]
+    }
+  }, {
+    "id" : "outputObject",
+    "optional" : false,
+    "advanced" : false,
+    "allow_multiple" : false,
+    "default_values" : [ "" ],
+    "field_type" : "text",
+    "text_options" : {
+      "valid_ws_types" : [ "KBaseFeatureValues.ExpressionMatrix" ],
+      "is_output_name" : true
+    }
+  }, {
+    "id" : "genomeObject",
+    "optional" : true,
+    "advanced" : false,
+    "allow_multiple" : false,
+    "default_values" : [ "" ],
+    "field_type" : "text",
+    "text_options" : {
+      "valid_ws_types" : [ "KBaseGenomes.Genome" ]
+    }
+  }, {
+    "id" : "fillMissingValues",
+    "optional" : true,
+    "advanced" : false,
+    "allow_multiple" : false,
+    "default_values":["0"],
+    "field_type" : "checkbox",
+    "checkbox_options":{
+      "checked_value": 1,
+      "unchecked_value": 0
+    }
+  }, {
+    "id" : "dataType",
+    "optional" : false,
+    "advanced" : false,
+    "allow_multiple" : false,
+    "default_values" : [ "log-ratio" ],
+    "field_type" : "dropdown",
+    "dropdown_options":{
+      "options": [
+        {
+          "value": "level",
+          "display": "Absolute Level",
+          "id": "level",
+          "ui_name": "Absolute Level"
+        },
+        {
+          "value": "ratio",
+          "display": "Ratio",
+          "id": "ratio",
+          "ui_name": "Ratio"
+        },
+        {
+          "value": "log-ratio",
+          "display": "Log-ratio",
+          "id": "log-ratio",
+          "ui_name": "Log-ratio"
+        }
+      ]
+    }
+  }, {
+    "id" : "dataScale",
+    "optional" : true,
+    "advanced" : false,
+    "allow_multiple" : false,
+    "default_values" : [ "" ],
+    "field_type" : "text"
+  } ],
+  "behavior" : {
+    "service-mapping" : {
+      "url" : "http://localhost:11111/",
+      "name" : "KBaseDataImport",
+      "method" : "upload",
+      "input_mapping" : [
+      ],
+      "output_mapping" : [
+      ]
+    }
+  },
+  "job_id_output_field": "job_id"
+}

--- a/methods/view_expression_heatmap/display.yaml
+++ b/methods/view_expression_heatmap/display.yaml
@@ -1,0 +1,42 @@
+#
+# Define basic display information
+#
+name     : View Expression Matrix Heatmap
+
+tooltip  : |
+    Explore an expression data matrix by viewing a sortable heatmap of selected features  
+
+screenshots :
+    []
+
+#
+# Define the set of other narrative methods that should be suggested to the user.
+#
+method-suggestions :
+    related :
+        []
+    next :
+        []
+
+
+#
+# Configure the display and description of the parameters
+#
+parameters :
+    input_expression_matrix :
+        ui-name : |
+            Expression Matrix
+        short-hint : |
+            Select the expression data to visualize
+
+    input_gene_ids :
+        ui-name : |
+            Features
+        short-hint : |
+            Select the features to include in the heatmap.
+
+description : |
+    View and explore expression data as a sortable heatmap.  Conditions/Samples are displayed on each row
+    with some summary statistics averaged across the selected features.  The conditions can be sorted
+    by those values.  Each of the selected features is represented in a simple heatmap in the table.
+    Mouseover the heatmap to view specific expression values.

--- a/methods/view_expression_heatmap/spec.json
+++ b/methods/view_expression_heatmap/spec.json
@@ -1,0 +1,60 @@
+{
+  "name" : "View Expression Heatmap",
+  "ver" : "1.0.0",
+  "authors" : [ ],
+  "contact" : "help@kbase.us",
+  "visble" : true,
+  "categories" : ["active"],
+  "widgets" : {
+    "input" : null,
+    "output" : "kbaseExpressionHeatmap"
+  },
+  "parameters" : [ {
+    "id" : "input_expression_matrix",
+    "optional" : false,
+    "advanced" : false,
+    "allow_multiple" : false,
+    "default_values" : [ "" ],
+    "field_type" : "text",
+    "text_options" : {
+      "valid_ws_types" : [ "KBaseFeatureValues.ExpressionMatrix" ]
+    }
+  } , {
+    "id" : "input_gene_ids",
+    "optional" : true,
+    "advanced" : false,
+    "allow_multiple" : false,
+    "default_values" : [ "" ],
+    "field_type" : "textsubdata",
+    "textsubdata_options" : {
+      "subdata_selection": {
+        "parameter_id" : "input_expression_matrix",
+        "subdata_included" : ["feature_mapping"],
+        "path_to_subdata": ["feature_mapping"],
+        "selection_id": ["value"]
+      },
+      "multiselection":true,
+      "show_src_obj":false,
+      "allow_custom":false
+    }
+  }
+],
+  "behavior" : {
+    "none" : {
+      "output_mapping" : [
+        {
+          "input_parameter": "input_expression_matrix",
+          "target_property": "expressionMatrixID"
+        },
+        {
+          "input_parameter": "input_gene_ids",
+          "target_property": "geneIds"
+        },
+        {
+          "narrative_system_variable": "workspace",
+          "target_property": "workspaceID"
+        }
+      ]
+    }
+  }
+}

--- a/methods/view_expression_matrix/display.yaml
+++ b/methods/view_expression_matrix/display.yaml
@@ -1,0 +1,40 @@
+#
+# Define basic display information
+#
+name     : View Expression Matrix
+
+tooltip  : |
+    View Expression Matrix
+
+screenshots :
+    []
+
+#
+# Define the set of other narrative methods that should be suggested to the user.
+#
+method-suggestions :
+    related :
+        []
+    next :
+        []
+
+
+#
+# Configure the display and description of the parameters
+#
+parameters :
+    param0 :
+        ui-name : |
+            Expression Matrix
+        short-hint : |
+            Select an expression matrix to view
+        long-hint  : |
+            Select an expression matrix to view
+
+
+description : |
+    View and explore Expression Matrix object in your workspace.
+
+
+technical-description : |
+    View and explore an Expression Matrix in your workspace.

--- a/methods/view_expression_matrix/spec.json
+++ b/methods/view_expression_matrix/spec.json
@@ -1,0 +1,37 @@
+{
+  "name" : "View Expression Matrix",
+  "ver" : "1.0.0",
+  "authors" : [ ],
+  "contact" : "help@kbase.us",
+  "visble" : true,
+  "categories" : ["viewers"],
+  "widgets" : {
+    "input" : null,
+    "output" : "kbaseExpressionMatrix"
+  },
+  "parameters" : [ {
+    "id" : "param0",
+    "optional" : false,
+    "advanced" : false,
+    "allow_multiple" : false,
+    "default_values" : [ "" ],
+    "field_type" : "text",
+    "text_options" : {
+      "valid_ws_types" : [ "KBaseFeatureValues.ExpressionMatrix" ]
+    }
+  } ],
+  "behavior" : {
+    "none" : {
+      "output_mapping" : [
+        {
+          "input_parameter": "param0",
+          "target_property": "expressionMatrixID"
+        },
+        {
+          "narrative_system_variable": "workspace",
+          "target_property": "workspaceID"
+        }
+      ]
+    }
+  }
+}

--- a/types/KBaseFeatureValues.ExpressionMatrix/display.yaml
+++ b/types/KBaseFeatureValues.ExpressionMatrix/display.yaml
@@ -1,0 +1,14 @@
+#
+# Define basic display information
+#
+name     : Expression Matrix
+subtitle : Expression Matrix object
+tooltip  : Expression Matrix object
+
+icon : none
+
+description : |
+    <p>This type describes expression matrix.</p>
+    
+    
+    

--- a/types/KBaseFeatureValues.ExpressionMatrix/spec.json
+++ b/types/KBaseFeatureValues.ExpressionMatrix/spec.json
@@ -1,0 +1,10 @@
+{
+    "ver":"0.1.0",
+    "view_method_ids":[
+        "view_expression_matrix"
+    ],
+    "import_method_ids":[
+        "import_expression_tsv_file"
+    ],
+    "landing_page_url_prefix":""
+}


### PR DESCRIPTION
This includes a method for uploading expression data from the narrative, a method for basic viewing of the expression data, a method for viewing selected features of an expression data set as a heatmap, and associating an expression data set with features from a Genome.

The methods have all been tested in CI for more than a week.

This PR puts these methods on the path to next.kbase.us, and then production.