### PR TITLE
temporarily disable method to find differentially expressed features

### DIFF
--- a/methods/expression_toolkit_filter_expression/spec.json
+++ b/methods/expression_toolkit_filter_expression/spec.json
@@ -4,7 +4,7 @@
   "authors" : [ ],
   "contact" : "help@kbase.us",
   "visble" : true,
-  "categories" : ["active"],
+  "categories" : ["inactive"],
   "widgets" : {
     "input" : null,
     "output" : "kbaseExpressionMatrix"


### PR DESCRIPTION
The backend code for this method is currently not working in production.  This will disable the method until those backend updates/fixes have been deployed.