### PR TITLE
Another hotfix for identifying differentially expressed genes

### DIFF
--- a/methods/expression_toolkit_filter_expression/spec.json
+++ b/methods/expression_toolkit_filter_expression/spec.json
@@ -50,8 +50,6 @@
       "default_values" : [ "300" ],
       "field_type" : "text",
       "text_options" : {
-        "validate_as": "int",
-        "min_int" : 1
       }
     }, {
       "id" : "filtered_expression",
@@ -83,7 +81,6 @@
       "default_values" : [ "0.05" ],
       "field_type" : "text",
       "text_options" : {
-        "validate_as": "float"
       }
   } ],
   "behavior" : {


### PR DESCRIPTION
Needed to remove validation of numeric fields, as the backend expects strings. We need to fix this on the backend later.