### PR TITLE
Hide "Compute Metagenome Annotation Set" method

### DIFF
--- a/methods/compute_metagenome_annotation_set/spec.json
+++ b/methods/compute_metagenome_annotation_set/spec.json
@@ -4,7 +4,7 @@
   "authors" : [ ],
   "contact" : "help@kbase.us",
   "visble" : true,
-  "categories" : ["active"],
+  "categories" : ["inactive"],
   "widgets" : {
     "input" : null,
     "output" : "AnnotationSetTable"


### PR DESCRIPTION
I *think* this one should be hidden, but don't have confirmation yet (see https://atlassian.kbase.us/browse/KBASE-2977).
Can always unhide if my guess turns out to be wrong.