### PR TITLE
Fix changed URLs.

### DIFF
--- a/methods/import_contigset_fasta_ftp/display.yaml
+++ b/methods/import_contigset_fasta_ftp/display.yaml
@@ -33,9 +33,9 @@ parameters :
         ui-name : |
             Name of FTP file
         short-hint : |
-            Provide a path to an FTP file with contigs in FASTA format (e.g., ftp://ftp.ncbi.nlm.nih.gov/genomes/Bacteria/Shewanella_MR_4_uid58345/NC_008321.fna)
+            Provide a path to an FTP file with contigs in FASTA format (e.g., ftp://ftp.ncbi.nlm.nih.gov/genomes/archive/old_refseq/Bacteria/Shewanella_MR_4_uid58345/NC_008321.fna)
         long-hint  : |
-            Provide a path to an FTP file with contigs in FASTA format (e.g., ftp://ftp.ncbi.nlm.nih.gov/genomes/Bacteria/Shewanella_MR_4_uid58345/NC_008321.fna)
+            Provide a path to an FTP file with contigs in FASTA format (e.g., ftp://ftp.ncbi.nlm.nih.gov/genomes/archive/old_refseq/Bacteria/Shewanella_MR_4_uid58345/NC_008321.fna)
 
     outputObject :
         ui-name : |

--- a/methods/import_genome_data_generic/display.yaml
+++ b/methods/import_genome_data_generic/display.yaml
@@ -50,9 +50,9 @@ parameters :
         ui-name : |
             FTP FOLDER
         short-hint : |
-            Enter the path to the FTP folder with the GBK-file(s).<br>ex) ftp://ftp.ncbi.nlm.nih.gov/genomes/Bacteria/Shewanella_MR_4_uid58345/
+            Enter the path to the FTP folder with the GBK-file(s).<br>ex) ftp://ftp.ncbi.nlm.nih.gov/genomes/archive/old_refseq/Bacteria/Shewanella_MR_4_uid58345/
         long-hint  : |
-            Enter the path to the FTP folder with the GBK-file(s).<br>ex) ftp://ftp.ncbi.nlm.nih.gov/genomes/Bacteria/Shewanella_MR_4_uid58345/
+            Enter the path to the FTP folder with the GBK-file(s).<br>ex) ftp://ftp.ncbi.nlm.nih.gov/genomes/archive/old_refseq/Bacteria/Shewanella_MR_4_uid58345/
 
     outputObject :
         ui-name : |

--- a/methods/import_genome_gbk_ftp/display.yaml
+++ b/methods/import_genome_gbk_ftp/display.yaml
@@ -32,7 +32,7 @@ parameters :
         ui-name : |
             Name of FTP file
         short-hint : |
-            Enter the path to the FTP file in GenBank format (for example, ftp://ftp.ncbi.nlm.nih.gov/genomes/Bacteria/Shewanella_MR_4_uid58345/NC_008321.gbk)
+            Enter the path to the FTP file in GenBank format (for example, ftp://ftp.ncbi.nlm.nih.gov/genomes/archive/old_refseq/Bacteria/Shewanella_MR_4_uid58345/NC_008321.gbk)
         long-hint  : |
             The uncompressed data must be less than 2G. File extension should be .gbk, .gb, .genbank, .gbf, or .gbff.
     outputObject :


### PR DESCRIPTION
NCBI reorganized its FTP site such that the example FTP URLs no longer work. This commit changes them to the updated location.