### PR TITLE
Removed "visble" [sic] line

### DIFF
--- a/methods/build_a_metabolic_model/spec.json
+++ b/methods/build_a_metabolic_model/spec.json
@@ -3,7 +3,6 @@
   "ver" : "1.0.0",
   "authors" : [ ],
   "contact" : "help@kbase.us",
-  "visble" : true,
   "categories" : ["active", "metabolic_modeling"],
   "widgets" : {
     "input" : null,


### PR DESCRIPTION
The "visible" (or, as it appears in many spec files, "visble") property is no longer supported. To hide methods, set  "categories" to "inactive".