### PR TITLE
Update spec.json

### DIFF
--- a/methods/expression_toolkit_filter_expression/spec.json
+++ b/methods/expression_toolkit_filter_expression/spec.json
@@ -3,8 +3,8 @@
   "ver" : "1.0.0",
   "authors" : [ ],
   "contact" : "help@kbase.us",
-  "visble" : true,
-  "categories" : ["active", "expression"],
+  "visble" : false,
+  "categories" : ["inactive", "expression"],
   "widgets" : {
     "input" : null,
     "output" : "kbaseExpressionMatrix"


### PR DESCRIPTION
I see multiple version of Identify Differential Expression in the narrative interface and app catalog in Next for development mode. Can we disable this one in favor of a more uptodate one from Shinjae.