### PR TITLE
Make convert_annotation_file_to_contig_set inactive

### DIFF
--- a/methods/convert_annotation_file_to_contig_set/spec.json
+++ b/methods/convert_annotation_file_to_contig_set/spec.json
@@ -4,7 +4,7 @@
   "authors" : [ "jkbaumohl", "mhenderson", "gaprice" ],
   "contact" : "help@kbase.us",
   "visble" : true,
-  "categories" : ["active", "assembly"],
+  "categories" : ["inactive", "assembly"],
   "widgets" : {
     "input" : null,
     "output" : "kbaseContigSetView"


### PR DESCRIPTION
Adding to master to quickly test this for compatibility with an old landing page (note there is an equivalent sdk app now in beta)