### PR TITLE
Copied header to description

### DIFF
--- a/apps/genome_assembly/display.yaml
+++ b/apps/genome_assembly/display.yaml
@@ -26,7 +26,7 @@ suggestions :
 
 
 header : |
-    <p>This multi-step app is deprecated and will no longer function after an upcoming KBase update. Any results produced by this app will be saved and you will be able to reproduce the functionality of this app with single-step apps.</p>
+    <p><b>Please note: This multi-step app is deprecated and will no longer function after an upcoming KBase update. However, any results produced by this app will be saved and you will be able to reproduce the functionality of this app with an equivalent sequence of single-step apps.</a></p>
 
     <p>The Assemble and Annotate Microbial Genome app assembles a set of Next-Generation Sequencing (NGS) short reads into contigs and then annotates the assembled contigs, calling genes and other genomic features and assigning biological functions. The user supplies a set of FASTA or FASTQ files of short reads and chooses from one of a variety of assembly algorithms. After the assembly, the contigs are automatically annotated by the KBase annotation pipeline, which includes assignment of biological functions derived from RAST (Rapid Annotations using Subsystems Technology). The resulting annotated genome can be exported in GenBank or FASTA format or used as input to other KBase apps such as Reconstruct Genome-scale Metabolic Model.</p>
     
@@ -40,9 +40,8 @@ step-descriptions :
 
 
 description : |
+    <p><b>Please note: This multi-step app is deprecated and will no longer function after an upcoming KBase update. However, any results produced by this app will be saved and you will be able to reproduce the functionality of this app with an equivalent sequence of single-step apps.</a></p>
+
     <p>The Assemble and Annotate Microbial Genome app assembles a set of Next-Generation Sequencing (NGS) short reads into contigs and then annotates the assembled contigs, calling genes and other genomic features and assigning biological functions. The user supplies a set of FASTA or FASTQ files of short reads and chooses from one of a variety of assembly algorithms. After the assembly, the contigs are automatically annotated by the KBase annotation pipeline, which includes assignment of biological functions derived from RAST (Rapid Annotations using Subsystems Technology). The resulting annotated genome can be exported in GenBank or FASTA format or used as input to other KBase apps such as Reconstruct Genome-scale Metabolic Model.</p>
     
     <p><a href="http://kbase.us/assemble-and-annotate-microbial-genome-app/" target="_blank">Tutorial for Assemble and Annotate Microbial Genome App</a></p>
-
-
-    


### PR DESCRIPTION
Mike said, "the App page is displaying the description field, not the header field. The header field is displayed if you actually open the app in the Narrative." Now the two fields both have the deprecated warning.