### PR TITLE
Combined info in header with info in description

### DIFF
--- a/apps/community_fba_modeling/display.yaml
+++ b/apps/community_fba_modeling/display.yaml
@@ -25,8 +25,8 @@ suggestions :
             [compare_two_metabolic_models_generic, run_flux_balance_analysis]
 
 header : |
-    <p>“This multi-step app is deprecated and will no longer function after an upcoming KBase update. Any results produced by this app will be saved and you will be able to reproduce the functionality of this app with single-step apps."</p>
-
+    <p><b>Please note: This multi-step app is deprecated and will no longer function after an upcoming KBase update. However, any results produced by this app will be saved and you will be able to reproduce the functionality of this app with single-step apps.</b></p>
+    
     <p>The Reconstruct Community Metabolic Model app generates a community metabolic model to be used with model-associated apps in KBase (e.g., "Run Flux Balance Analysis") to predict fluxes. To begin, the user may either upload a set of metabolic models or select a set of public metabolic models already present in KBase. KBase will then assemble these models into a single compartmentalized community model. The user may also select or upload a growth condition to which the community model will be gap filled.</p>
     
     <p><a href="http://kbase.us/reconstruct-community-metabolic-model/" target="_blank">Tutorial for Reconstruct Community Metabolic Model App</a></p>
@@ -43,12 +43,10 @@ step-descriptions :
 
 
 description : |
+    <p><b>Please note: This multi-step app is deprecated and will no longer function after an upcoming KBase update. However, any results produced by this app will be saved and you will be able to reproduce the functionality of this app with single-step apps.</b></p>
+    
     <p>The Reconstruct Community Metabolic Model app generates a community metabolic model to be used with model-associated apps in KBase (e.g., "Run Flux Balance Analysis") to predict fluxes. To begin, the user may either upload a set of metabolic models or select a set of public metabolic models already present in KBase. KBase will then assemble these models into a single compartmentalized community model. The user may also select or upload a growth condition to which the community model will be gap filled.</p>
     
     <p><a href="http://kbase.us/reconstruct-community-metabolic-model/" target="_blank">Tutorial for Reconstruct Community Metabolic Model App</a></p>
 
     <p><a href="http://kbase.us/metabolic-modeling-faq/">Metabolic Modeling FAQ</a></p>
-
-    
-    
-    


### PR DESCRIPTION
The App page shows the description field, not the header field. The header field is displayed if you actually open the app in the Narrative. Now the two fields both have the deprecation warning.