### PR TITLE
Combined info in header with info in description

### DIFF
--- a/apps/genome_comparison/display.yaml
+++ b/apps/genome_comparison/display.yaml
@@ -11,7 +11,7 @@ screenshots : []
 
 
 header : |
-    <p>“This multi-step app is deprecated and will no longer function after an upcoming KBase update. Any results produced by this app will be saved and you will be able to reproduce the functionality of this app with single-step apps."</p>
+    <p><b>Please note: This multi-step app is deprecated and will no longer function after an upcoming KBase update. However, any results produced by this app will be saved and you will be able to reproduce the functionality of this app with single-step apps.</b></p>
 
     <p>The Compare Genomes from Pangenome app conducts a detailed comparison of genomes on the basis of protein sequence similarity and function. It begins by creating a pangenome for a set of closely related organisms. The pangenome is defined as the set of conserved and variable genes that are found within a set of related genomes. In many cases, this is a desirable analysis for understanding which genes were gained and lost between strains, or for inferring which genes may confer a phenotype to a given strain.</p>
     
@@ -25,10 +25,8 @@ step-descriptions :
 
 
 description : |
+    <p><b>Please note: This multi-step app is deprecated and will no longer function after an upcoming KBase update. However, any results produced by this app will be saved and you will be able to reproduce the functionality of this app with single-step apps.</b></p>
+
     <p>The Compare Genomes from Pangenome app conducts a detailed comparison of genomes on the basis of protein sequence similarity and function. It begins by creating a pangenome for a set of closely related organisms. The pangenome is defined as the set of conserved and variable genes that are found within a set of related genomes. In many cases, this is a desirable analysis for understanding which genes were gained and lost between strains, or for inferring which genes may confer a phenotype to a given strain.</p>
     
     <p><a href="http://kbase.us/compare-genomes-from-pangenome-app/" target="_blank">Tutorial for Compare Genomes from Pangenome App</a></p>
-
-
-
-


### PR DESCRIPTION
The App page shows the description field, not the header field. The header field is displayed if you actually open the app in the Narrative. Now the two fields both have the deprecation warning.