### PR TITLE
Added CSV exporter for DomainAnnotation type (PTV-572)

### DIFF
--- a/types/KBaseGeneFamilies.DomainAnnotation/spec.json
+++ b/types/KBaseGeneFamilies.DomainAnnotation/spec.json
@@ -3,5 +3,8 @@
     "view_method_ids":[
         "NarrativeViewers/view_domain_annotation"
     ],
+    "export_functions":{
+        "CSV": "DomainAnnotation/export_csv"
+    },
     "landing_page_url_prefix":""
 }


### PR DESCRIPTION
This exposes the CSV exporter from the DomainAnnotation module.
It was added in version 1.0.2 of that module, which is currently in beta:
https://narrative.kbase.us/#catalog/modules/DomainAnnotation